### PR TITLE
Multiple tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,3 @@ npm run deploy
 ```
 
 This will create a zip file located at `build/drop_box.zip`. The zip archive contains the package which is cleaned up with PHP CS Fixer and don't contain any unnecessary files that are used in development. 
-
-## TODO
-
-- General
-    - Test TUS server library
-    - Implement S3 Storage
-    - Implement Settings page
-    - Implement Public URL Controller + Routing + Add "Get Public URL" menu item to context menu
-    - Implement permissions check

--- a/controller.php
+++ b/controller.php
@@ -7,6 +7,7 @@ use Concrete\Core\File\Filesystem;
 use Concrete\Core\Package\Package;
 use Concrete\Core\Package\PackageService;
 use Concrete\Core\Tree\Node\Type\FileFolder;
+use Concrete5\DropBox\Console\Command\RemoveExpiredFiles;
 use Concrete5\DropBox\ServiceProvider;
 use Concrete\Core\File\StorageLocation\Type\Type;
 
@@ -74,6 +75,11 @@ class Controller extends Package
     {
         if (file_exists($this->getPackagePath() . "/vendor")) {
             require_once $this->getPackagePath() . "/vendor/autoload.php";
+        }
+
+        if ($this->app->isRunThroughCommandLineInterface()) {
+            $console = $this->app->make('console');
+            $console->add(new RemoveExpiredFiles());
         }
 
         /** @var ServiceProvider $serviceProvider */

--- a/controller.php
+++ b/controller.php
@@ -2,15 +2,18 @@
 
 namespace Concrete\Package\DropBox;
 
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\File\Filesystem;
 use Concrete\Core\Package\Package;
 use Concrete\Core\Package\PackageService;
+use Concrete\Core\Tree\Node\Type\FileFolder;
 use Concrete5\DropBox\ServiceProvider;
 use Concrete\Core\File\StorageLocation\Type\Type;
 
 class Controller extends Package
 {
     protected $appVersionRequired = '8.0.0';
-    protected $pkgVersion = '0.2.0';
+    protected $pkgVersion = '0.2.1';
     protected $pkgHandle = 'drop_box';
     protected $pkgDescription = '';
     protected $pkgAutoloaderRegistries = ['src' => 'Concrete5\DropBox'];
@@ -37,6 +40,19 @@ class Controller extends Package
 
         if (!$storageObject instanceof Type) {
             Type::add('s3', t('Amazon S3'), $pkg);
+        }
+
+        // Create BrandCentral folder
+        $filesystem = new Filesystem();
+        $folderName = t("Drop Box");
+        $rootFolder = $filesystem->getRootFolder();
+        $folder = FileFolder::getNodeByName($folderName);
+
+        if (!$folder instanceof FileFolder) {
+            $createdFolder = $filesystem->addFolder($rootFolder, $folderName);
+            /** @var Repository $config */
+            $config = $this->app->make(Repository::class);
+            $config->save("drop_box.target_upload_directory_id", $createdFolder->getTreeNodeID());
         }
     }
 

--- a/controllers/dialog/uploaded_file/bulk/delete.php
+++ b/controllers/dialog/uploaded_file/bulk/delete.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Concrete\Package\DropBox\Controller\Dialog\UploadedFile\Bulk;
+
+use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
+use Concrete\Core\Application\EditResponse;
+use Concrete\Core\Entity\File\File;
+use Concrete\Core\Validation\CSRF\Token;
+use Concrete5\DropBox\Entity\UploadedFile;
+use Doctrine\ORM\EntityManagerInterface;
+
+class Delete extends BackendInterfaceController
+{
+    protected $viewPath = '/dialogs/uploaded_file/bulk/delete';
+
+    /** @var EntityManagerInterface */
+    protected $entityManager;
+
+    protected function canAccess()
+    {
+        return true;
+    }
+
+    public function on_start()
+    {
+        parent::on_start();
+
+        $this->entityManager = $this->app->make(EntityManagerInterface::class);
+    }
+
+    public function view()
+    {
+        $uploadedFileEntries = [];
+
+        $items = $this->request->query->get("item");
+
+        if (!is_array($items)) {
+            $items = [$this->request->query->get("item")];
+        }
+
+        foreach ($items as $ids) {
+            list($primaryIdentifier, $fileIdentifier) = explode("_", $ids);
+
+            $uploadedFileEntry = $this->entityManager->getRepository(UploadedFile::class)->findOneBy([
+                "primaryIdentifier" => $primaryIdentifier,
+                "fileIdentifier" => $fileIdentifier
+            ]);
+
+            if ($uploadedFileEntry instanceof UploadedFile) {
+                $uploadedFileEntries[] = $uploadedFileEntry;
+            }
+        }
+
+        $this->set("uploadedFileEntries", $uploadedFileEntries);
+    }
+
+    public function submit()
+    {
+        $editResponse = new EditResponse();
+
+        /** @var Token $token */
+        $token = $this->app->make(Token::class);
+
+        if (!$token->validate('bulk_delete_uploaded_file_entries')) {
+            throw new \Exception($token->getErrorMessage());
+        }
+
+        $items = $this->request->request->get("uploadedFileEntries");
+
+        foreach ($items as $ids) {
+            list($primaryIdentifier, $fileIdentifier) = explode("_", $ids);
+
+            $uploadedFileEntry = $this->entityManager->getRepository(UploadedFile::class)->findOneBy([
+                "primaryIdentifier" => $primaryIdentifier,
+                "fileIdentifier" => $fileIdentifier
+            ]);
+
+            if ($uploadedFileEntry instanceof UploadedFile) {
+                $file = $uploadedFileEntry->getFile();
+
+                if ($file instanceof File) {
+                    $file->delete();
+                }
+
+                $this->entityManager->remove($uploadedFileEntry);
+            }
+        }
+
+        $this->entityManager->flush();
+
+        $editResponse->setTitle(t("Entries successfully deleted"));
+        $editResponse->setMessage(t("The entries were successfully deleted."));
+        return $editResponse->outputJSON();
+    }
+}

--- a/controllers/single_page/dashboard/files/drop_box.php
+++ b/controllers/single_page/dashboard/files/drop_box.php
@@ -243,6 +243,8 @@ class DropBox extends DashboardPageController
         $this->set('headerMenu', $headerMenu);
         $this->set('headerSearch', $headerSearch);
 
+        $this->set('resultsBulkMenu', $this->app->make(\Concrete5\DropBox\Search\UploadedFile\Menu\MenuFactory::class)->createBulkMenu());
+
         $this->setThemeViewTemplate('full.php');
     }
 

--- a/controllers/single_page/dashboard/files/drop_box.php
+++ b/controllers/single_page/dashboard/files/drop_box.php
@@ -176,6 +176,12 @@ class DropBox extends DashboardPageController
         ]);
 
         if ($entry instanceof UploadedFileEntity) {
+            $file = $entry->getFile();
+
+            if ($file instanceof \Concrete\Core\Entity\File\File) {
+                $file->delete();
+            }
+            
             $this->entityManager->remove($entry);
             $this->entityManager->flush();
 

--- a/controllers/single_page/dashboard/files/drop_box.php
+++ b/controllers/single_page/dashboard/files/drop_box.php
@@ -181,7 +181,7 @@ class DropBox extends DashboardPageController
             if ($file instanceof \Concrete\Core\Entity\File\File) {
                 $file->delete();
             }
-            
+
             $this->entityManager->remove($entry);
             $this->entityManager->flush();
 

--- a/controllers/single_page/dashboard/system/files/drop_box_settings.php
+++ b/controllers/single_page/dashboard/system/files/drop_box_settings.php
@@ -35,6 +35,7 @@ class DropBoxSettings extends DashboardPageController
 
         $this->set('storageLocationList', $storageLocationList);
         $this->set('storageLocation', (int)$this->config->get("drop_box.storage_location", 0));
+        $this->set('uploadDirectoryId', (int)$this->config->get("drop_box.target_upload_directory_id", 0));
     }
 
     private function validate()
@@ -63,6 +64,7 @@ class DropBoxSettings extends DashboardPageController
 
         if ($this->request->getMethod() === "POST" && $this->validate()) {
             $this->config->save("drop_box.storage_location", (int)$this->request->request->get("storageLocation"));
+            $this->config->save("drop_box.target_upload_directory_id", (int)$this->request->request->get("uploadDirectoryId"));
 
             $this->set("success", t("The settings has been updated successfully."));
         }

--- a/jobs/remove_expired_files.php
+++ b/jobs/remove_expired_files.php
@@ -34,11 +34,14 @@ class RemoveExpiredFiles extends Job
 
     public function run()
     {
-        $rows = $this->connection->fetchAll("SELECT * FROM UploadedFile WHERE DATE_ADD(createdAt, INTERVAL 45 DAY) > NOW()");
+        $rows = $this->connection->fetchAll("SELECT * FROM UploadedFile WHERE DATE_ADD(createdAt, INTERVAL 45 DAY) < NOW()");
 
         foreach ($rows as $row) {
             $file = File::getByID($row["fID"]);
-            $file->delete();
+
+            if ($file instanceof \Concrete\Core\Entity\File\File) {
+                $file->delete();
+            }
 
             $entry = $this->entityManager->getRepository(UploadedFile::class)->findOneBy([
                 "primaryIdentifier" => $row["primaryIdentifier"],

--- a/routes/dialogs/uploaded_file.php
+++ b/routes/dialogs/uploaded_file.php
@@ -8,6 +8,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * Namespace: Concrete\Package\DropBox\Controller\Dialog\UploadedFile
  */
 
+$router->all('/bulk/delete', 'Bulk\Delete::view');
+$router->all('/bulk/delete/submit', 'Bulk\Delete::submit');
 $router->all('/advanced_search', 'AdvancedSearch::view');
 $router->all('/advanced_search/add_field', 'AdvancedSearch::addField');
 $router->all('/advanced_search/submit', 'AdvancedSearch::submit');

--- a/single_pages/dashboard/files/drop_box.php
+++ b/single_pages/dashboard/files/drop_box.php
@@ -12,6 +12,7 @@ defined('C5_EXECUTE') or die('Access denied');
 
 /** @noinspection DuplicatedCode */
 
+use Concrete\Core\Application\UserInterface\ContextMenu\DropdownMenu;
 use Concrete\Core\Application\UserInterface\ContextMenu\MenuInterface;
 use Concrete5\DropBox\Entity\UploadedFile;
 use Concrete5\DropBox\Menu;
@@ -22,7 +23,7 @@ use Concrete5\DropBox\Search\UploadedFile\Result\Result;
 use Concrete\Core\Support\Facade\Url;
 
 /** @var Result|null $result */
-
+/** @var DropdownMenu $resultsBulkMenu */
 /** @var MenuInterface $menu */
 /** @var Result $result */
 
@@ -52,6 +53,10 @@ use Concrete\Core\Support\Facade\Url;
                                 <?php echo t("Toggle Dropdown"); ?>
                             </span>
                         </button>
+
+                        <div data-search-menu="dropdown">
+                            <?php echo $resultsBulkMenu->getMenuElement(); ?>
+                        </div>
                     </div>
                 </th>
 
@@ -85,7 +90,7 @@ use Concrete\Core\Support\Facade\Url;
                             <!--suppress HtmlFormInputWithoutLabel -->
                             <input data-search-checkbox="individual"
                                    type="checkbox"
-                                   data-item-id="<?php echo $uploadedFileEntry->getPrimaryIdentifier() ?>"/>
+                                   data-item-id="<?php echo $uploadedFileEntry->getPrimaryIdentifier() ?>_<?php echo $uploadedFileEntry->getFileIdentifier() ?>"/>
                         <?php endif; ?>
                     </td>
 

--- a/single_pages/dashboard/system/files/drop_box_settings.php
+++ b/single_pages/dashboard/system/files/drop_box_settings.php
@@ -3,18 +3,22 @@
 defined('C5_EXECUTE') or die('Access denied');
 
 use Concrete\Core\Form\Service\Form;
+use Concrete\Core\Form\Service\Widget\FileFolderSelector;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\Url;
 use Concrete\Core\Validation\CSRF\Token;
 
 /** @var array $storageLocationList */
 /** @var int $storageLocation */
+/** @var int $uploadDirectoryId */
 
 $app = Application::getFacadeApplication();
 /** @var Form $form */
 $form = $app->make(Form::class);
 /** @var Token $token */
 $token = $app->make(Token::class);
+/** @var FileFolderSelector $fileFolderSelector */
+$fileFolderSelector = $app->make(FileFolderSelector::class);
 ?>
 
 <form action="#" method="post">
@@ -33,9 +37,14 @@ $token = $app->make(Token::class);
         ); ?>
     </div>
 
+    <div class="form-group">
+        <?php echo $form->label("uploadDirectoryId", t("Upload Destination")); ?>
+        <?php echo $fileFolderSelector->selectFileFolder('uploadDirectoryId', $uploadDirectoryId); ?>
+    </div>
+
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <div class="pull-right">
+            <div class="float-right">
                 <button type="submit" class="btn btn-primary">
                     <?php echo t("Save"); ?>
                 </button>

--- a/src/Console/Command/RemoveExpiredFiles.php
+++ b/src/Console/Command/RemoveExpiredFiles.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Concrete5\DropBox\Console\Command;
+
+use Bitter\EntityDesigner\Generator\GeneratorService;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\File\File;
+use Concrete\Core\Support\Facade\Application;
+use Concrete5\DropBox\Entity\UploadedFile;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+
+class RemoveExpiredFiles extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('drop-box:remove-expired-files')
+            ->setDescription(t('Remove expired files.'));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $app = Application::getFacadeApplication();
+
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var Connection $connection */
+        $connection= $app->make(Connection::class);
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $app->make(EntityManagerInterface::class);
+
+        try {
+            $rows = $connection->fetchAll("SELECT * FROM UploadedFile WHERE DATE_ADD(createdAt, INTERVAL 45 DAY) < NOW()");
+
+            foreach ($rows as $row) {
+                $file = File::getByID($row["fID"]);
+
+                if ($file instanceof \Concrete\Core\Entity\File\File) {
+                    $file->delete();
+                }
+
+                $entry = $entityManager->getRepository(UploadedFile::class)->findOneBy([
+                    "primaryIdentifier" => $row["primaryIdentifier"],
+                    "fileIdentifier" => $row["fileIdentifier"]
+                ]);
+
+                if ($entry instanceof UploadedFile) {
+                    $entityManager->remove($entry);
+                }
+            }
+
+            $entityManager->flush();
+
+            $io->success(t2('%s file removed', '%s files removed', count($rows)));
+        } catch (Exception $error) {
+            $io->error($error->getMessage());
+        }
+    }
+}

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -4,6 +4,7 @@ namespace Concrete5\DropBox;
 
 use Concrete\Core\Application\UserInterface\ContextMenu\DropdownMenu;
 use Concrete\Core\Application\UserInterface\ContextMenu\Item\LinkItem;
+use Concrete\Core\Entity\File\File;
 use Concrete\Core\Support\Facade\Url;
 use Concrete5\DropBox\Entity\UploadedFile;
 
@@ -14,6 +15,15 @@ class Menu extends DropdownMenu
     public function __construct(UploadedFile $uploadedFileEntry)
     {
         parent::__construct();
+
+        if ($uploadedFileEntry->getFile() instanceof File) {
+            $this->addItem(
+                new LinkItem(
+                    (string)Url::to("/dashboard/files/details", $uploadedFileEntry->getFile()->getFileID()),
+                    t('View Details')
+                )
+            );
+        }
 
         $this->addItem(
             new LinkItem(

--- a/src/Search/UploadedFile/Menu/MenuFactory.php
+++ b/src/Search/UploadedFile/Menu/MenuFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Concrete5\DropBox\Search\UploadedFile\Menu;
+
+use Concrete\Core\Application\UserInterface\ContextMenu\DropdownMenu;
+use Concrete\Core\Application\UserInterface\ContextMenu\Item\LinkItem;
+use Concrete\Core\Support\Facade\Url;
+
+class MenuFactory
+{
+
+    public function createBulkMenu(): DropdownMenu
+    {
+        $menu = new DropdownMenu();
+
+        $menu->addItem(new LinkItem('#', t('Delete'), [
+            'data-bulk-action-type' => 'dialog',
+            'data-bulk-action-title' => t('Delete'),
+            'data-bulk-action-url' => Url::to('/ccm/system/dialogs/uploaded_file/bulk/delete'),
+            'data-bulk-action-dialog-width' => '500',
+            'data-bulk-action-dialog-height' => '400',
+        ]));
+
+        return $menu;
+    }
+
+}

--- a/src/UploadedFileList.php
+++ b/src/UploadedFileList.php
@@ -18,7 +18,7 @@ use Closure;
 class UploadedFileList extends ItemList implements PagerProviderInterface, PaginationProviderInterface
 {
     protected $isFulltextSearch = false;
-    protected $autoSortColumns = ['t0.PrimaryIdentifier', 't0.FileIdentifier', 't0.File', 't0.Owner', 't0.CreatedAt'];
+    protected $autoSortColumns = ['t0.primaryIdentifier', 't0.fileIdentifier', 't0.file', 't0.owner', 't0.createdAt'];
     protected $permissionsChecker = -1;
 
     public function createQuery()

--- a/views/dialogs/uploaded_file/bulk/delete.php
+++ b/views/dialogs/uploaded_file/bulk/delete.php
@@ -1,0 +1,111 @@
+<?php
+
+defined('C5_EXECUTE') or die("Access Denied.");
+
+use Concrete\Core\Entity\File\File;
+use Concrete\Core\Entity\File\Version;
+use Concrete\Core\Form\Service\Form;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Validation\CSRF\Token;
+use Concrete\Package\DropBox\Controller\Dialog\UploadedFile\Bulk\Delete;
+use Concrete5\DropBox\Entity\UploadedFile;
+
+/** @var Delete $controller */
+/** @var UploadedFile[] $uploadedFileEntries */
+
+$app = Application::getFacadeApplication();
+/** @var Form $form */
+$form = $app->make(Form::class);
+/** @var Token $token */
+$token = $app->make(Token::class);
+?>
+
+<p>
+    <?php echo t('Are you sure you would like to delete the following uploaded files?'); ?>
+</p>
+
+<form method="post" data-dialog-form="save-file-set" action="<?php echo h($controller->action('submit')); ?>">
+
+    <?php echo $token->output("bulk_delete_uploaded_file_entries"); ?>
+
+    <?php foreach ($uploadedFileEntries as $uploadedFileEntry) { ?>
+        <?php echo $form->hidden("uploadedFileEntries[]", $uploadedFileEntry->getPrimaryIdentifier() . "_" . $uploadedFileEntry->getFileIdentifier()); ?>
+    <?php } ?>
+
+    <div class="ccm-ui">
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>
+                    <?php echo t('Primary Identifier') ?>
+                </th>
+
+                <th>
+                    <?php echo t('File Identifier') ?>
+                </th>
+
+                <th>
+                    <?php echo t('File') ?>
+                </th>
+
+                <th>
+                    <?php echo t('Owner') ?>
+                </th>
+            </tr>
+            </thead>
+
+            <tbody>
+            <?php foreach ($uploadedFileEntries as $uploadedFileEntry) { ?>
+                <tr>
+                    <td>
+                        <?php echo $uploadedFileEntry->getPrimaryIdentifier(); ?>
+                    </td>
+
+                    <td>
+                        <?php echo $uploadedFileEntry->getFileIdentifier(); ?>
+                    </td>
+
+                    <td>
+                        <?php
+                        $fileName = "";
+
+                        if ($uploadedFileEntry->getFile() instanceof File) {
+                            $approvedVersion = $uploadedFileEntry->getFile()->getApprovedVersion();
+
+                            if ($approvedVersion instanceof Version) {
+                                $fileName = $approvedVersion->getFileName();
+                            }
+                        }
+
+                        echo $fileName;
+                        ?>
+                    </td>
+
+                    <td>
+                        <?php
+                        $userName = "";
+
+                        if ($uploadedFileEntry->getOwner() instanceof \Concrete\Core\Entity\User\User) {
+                            $userName = $uploadedFileEntry->getOwner()->getUserName();
+                        }
+
+                        echo $userName;
+                        ?>
+                    </td>
+                </tr>
+            <?php } ?>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="dialog-buttons">
+        <button class="btn btn-secondary float-left" data-dialog-action="cancel">
+            <?php echo t('Cancel'); ?>
+        </button>
+
+        <button type="button" data-dialog-action="submit" class="btn btn-primary float-right">
+            <?php echo t('Delete'); ?>
+        </button>
+    </div>
+
+</form>


### PR DESCRIPTION

- Add CLI command for removing expired uploads
- Fix logic: Remove associated file from the concrete5 file manager when removing a UploadedFile-entry
- Add "View Details" to the context menu of the UploadedFile list view with a link to the concrete5 file details view
- Fix sorting files in list view
- Make bulk delete dialog work and look like the core's file bulk delete dialog
- Create a "Drop Box" folder beneath the root folder on install/update if not available and set it as default in the drop box settings
- Add a folder selector in the upload settings page (use FileFolderSelector widget)
